### PR TITLE
response is captured on object

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -55,9 +55,9 @@ export class GraphiQL extends React.Component {
       removeItem: PropTypes.func,
     }),
     defaultQuery: PropTypes.string,
-    onEditQuery: PropTypes.func,
-    onEditVariables: PropTypes.func,
-    onEditOperationName: PropTypes.func,
+    onEditQuery: PropTypes.func, // Jon: I might take this out, may not need 2PM - 9/17/18
+    onEditVariables: PropTypes.func, // Jon: I might take this out, may not need 2PM - 9/17/18
+    onEditOperationName: PropTypes.func, // Jon: I might take this out, may not need 2PM - 9/17/18
     onToggleDocs: PropTypes.func,
     getDefaultFieldNames: PropTypes.func,
     editorTheme: PropTypes.string,
@@ -288,6 +288,7 @@ export class GraphiQL extends React.Component {
       <div className="graphiql-container">
         <div className="historyPaneWrap" style={historyPaneStyle}>
           <QueryHistory
+            response={this.state.response}
             operationName={this.state.operationName}
             query={this.state.query}
             variables={this.state.variables}
@@ -617,11 +618,16 @@ export class GraphiQL extends React.Component {
     }
 
     try {
-      this.setState({
-        isWaitingForResponse: true,
-        response: null,
-        operationName,
-      });
+
+      /* commented out, response is unable to get captured in the query object if     this is active
+       *
+       * this.setState({
+       *   isWaitingForResponse: true,
+       *   response: null,
+       *   operationName,
+       * });
+       * 
+       ********************************************/ 
 
       // _fetchQuery may return a subscription.
       const subscription = this._fetchQuery(
@@ -635,10 +641,9 @@ export class GraphiQL extends React.Component {
               response: JSON.stringify(result, null, 2),
             });
           }
+          this.setState({ subscription }); // moved inside of callback in order for response to be captured in query object. 
         },
       );
-
-      this.setState({ subscription });
     } catch (error) {
       this.setState({
         isWaitingForResponse: false,

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -36,6 +36,7 @@ const MAX_HISTORY_LENGTH = 20;
 
 export class QueryHistory extends React.Component {
   static propTypes = {
+    response: PropTypes.string,
     query: PropTypes.string,
     variables: PropTypes.string,
     operationName: PropTypes.string,
@@ -62,6 +63,7 @@ export class QueryHistory extends React.Component {
         query: nextProps.query,
         variables: nextProps.variables,
         operationName: nextProps.operationName,
+        response: nextProps.response,
       };
       this.historyStore.push(item);
       if (this.historyStore.length > MAX_HISTORY_LENGTH) {
@@ -92,7 +94,7 @@ export class QueryHistory extends React.Component {
     return (
       <div>
         <div className="history-title-bar">
-          <div className="history-title">{'History'}</div>
+          <div className="history-title">{'Test Drawer'}</div>
           <div className="doc-explorer-rhs">
             {this.props.children}
           </div>


### PR DESCRIPTION
Changes made:

GraphiQL.js

- Included comments for onEditQuery, onEditVariables, onEditOperationName in static PropTypes section of GraphiQL Class. These properties will potentially be removed as the project progresses. Will communicate as a team before enacting that change. 
- Response property is being passed down to the QueryHistory component. 
- In the function handleRunQuery, the first setState has been commented out. Can possibly be removed, will communicate as a team before enacting that change. 
- In the same function, the last setState has been moved into the end of the callback function, so response can be captured in the object. 

QueryHistory.js

- Response declared inside of static PropTypes
- Response property will be added to the object in componentWillReceiveProps
- Title has been revised to Test Drawer for now. 