### PR TITLE
Queries can be favorited and no duplicates queries will be created

### DIFF
--- a/src/components/HistoryQuery.js
+++ b/src/components/HistoryQuery.js
@@ -10,6 +10,7 @@ import PropTypes from 'prop-types';
 
 export default class HistoryQuery extends React.Component {
   static propTypes = {
+    response: PropTypes.string, 
     favorite: PropTypes.bool,
     favoriteSize: PropTypes.number,
     handleEditLabel: PropTypes.func,
@@ -88,6 +89,7 @@ export default class HistoryQuery extends React.Component {
     this.props.onSelect(
       this.props.query,
       this.props.variables,
+      this.props.response,
       this.props.operationName,
       this.props.label,
     );
@@ -99,8 +101,8 @@ export default class HistoryQuery extends React.Component {
       this.props.query,
       this.props.variables,
       this.props.operationName,
-      this.props.label,
       this.props.favorite,
+      this.props.response,
     );
   }
 

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 import QueryStore from '../utility/QueryStore';
 import HistoryQuery from './HistoryQuery';
 
-const shouldSaveQuery = (nextProps, current, lastQuerySaved) => {
-  if (nextProps.queryID === current.queryID) {
+const shouldSaveQuery = (nextProps, currentProps, allHistoryQueries) => {
+  if (nextProps.queryID === currentProps.queryID) {
     return false;
   }
   try {
@@ -13,23 +13,30 @@ const shouldSaveQuery = (nextProps, current, lastQuerySaved) => {
   } catch (e) {
     return false;
   }
-  if (!lastQuerySaved) {
-    return true;
-  }
-  if (
-    JSON.stringify(nextProps.query) === JSON.stringify(lastQuerySaved.query)
-  ) {
-    if (
-      JSON.stringify(nextProps.variables) ===
-      JSON.stringify(lastQuerySaved.variables)
-    ) {
-      return false;
+
+  // change the value of execute if a duplicate is found below
+  let execute = true;
+
+  // iterate through all existing history queries and ensure no duplicates are created. 
+  allHistoryQueries.forEach((entry) => {
+    if (JSON.stringify(nextProps.operationName) === JSON.stringify(entry.operationName)) {
+      if (
+        JSON.stringify(nextProps.query) === JSON.stringify(entry.query)
+        ) {
+        if (
+          JSON.stringify(nextProps.variables) ===
+          JSON.stringify(entry.variables)
+        ) {
+          execute = false;
+        }
+        if (!nextProps.variables && !entry.variables) {
+          execute = false;
+        }
+        execute = false;
+      }
     }
-    if (!nextProps.variables && !lastQuerySaved.variables) {
-      return false;
-    }
-  }
-  return true;
+  })
+  return execute;
 };
 
 const MAX_HISTORY_LENGTH = 20;

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -130,7 +130,7 @@ export class QueryHistory extends React.Component {
       this.selectedForTestingStore.push(item);
       this.historyStore.edit(item);
     } else if (favorite) {
-      delete item.favorite;
+      item.favorite = false;
       this.historyStore.edit(item);
       this.selectedForTestingStore.delete(item);
     }

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -102,36 +102,44 @@ export class QueryHistory extends React.Component {
 
   createQueryNodes = (queryStore) => {
     const nodes = queryStore.slice().reverse();
-    return nodes.map((entry, i) => {
+    return nodes.map((node, i) => {
       return (
         <HistoryQuery
+          response={this.props.response}
           handleEditLabel={this.editLabel}
           handleToggleFavorite={this.toggleFavorite}
           key={i}
           onSelect={this.props.onSelectQuery}
-          {...query}
+          {...node}
         />
       );
     });
   };
 
-  toggleFavorite = (query, variables, operationName, label, favorite) => {
+  toggleFavorite = (query, variables, operationName, favorite, response) => {
     const item = {
       query,
       variables,
       operationName,
-      label,
+      response,
     };
-    if (!this.favoriteStore.contains(item)) {
+
+    // if the item does not exist in the selectedForTestingStore, create a property favorite on the item and set it to true. Add the item to the store and edit the same item in the historyStore. 
+    if (!this.selectedForTestingStore.contains(item)) {
       item.favorite = true;
-      this.favoriteStore.push(item);
+      this.selectedForTestingStore.push(item);
+      this.historyStore.edit(item);
     } else if (favorite) {
-      item.favorite = false;
-      this.favoriteStore.delete(item);
+      delete item.favorite;
+      this.historyStore.edit(item);
+      this.selectedForTestingStore.delete(item);
     }
-    this.setState({ ...this.historyStore.items, ...this.favoriteStore.items });
+    // set state with the changed queries
+    const historyQueries = this.historyStore.items;
+    this.setState({ historyQueries });
   };
 
+  // Jon: Label functionality not needed, will discuss with team before removal - 9/17/18
   editLabel = (query, variables, operationName, label, favorite) => {
     const item = {
       query,

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -84,18 +84,7 @@ export class QueryHistory extends React.Component {
   }
 
   render() {
-    const queries = this.state.queries.slice().reverse();
-    const queryNodes = queries.map((query, i) => {
-      return (
-        <HistoryQuery
-          handleEditLabel={this.editLabel}
-          handleToggleFavorite={this.toggleFavorite}
-          key={i}
-          onSelect={this.props.onSelectQuery}
-          {...query}
-        />
-      );
-    });
+    const queryNodes = this.createQueryNodes(this.state.history) 
     return (
       <div>
         <div className="history-title-bar">
@@ -110,6 +99,21 @@ export class QueryHistory extends React.Component {
       </div>
     );
   }
+
+  createQueryNodes = (queryStore) => {
+    const nodes = queryStore.slice().reverse();
+    return nodes.map((entry, i) => {
+      return (
+        <HistoryQuery
+          handleEditLabel={this.editLabel}
+          handleToggleFavorite={this.toggleFavorite}
+          key={i}
+          onSelect={this.props.onSelectQuery}
+          {...query}
+        />
+      );
+    });
+  };
 
   toggleFavorite = (query, variables, operationName, label, favorite) => {
     const item = {

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -84,7 +84,7 @@ export class QueryHistory extends React.Component {
   }
 
   render() {
-    const queryNodes = this.createQueryNodes(this.state.history) 
+    const queryNodes = this.createQueryNodes(this.state.historyQueries) 
     return (
       <div>
         <div className="history-title-bar">

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -55,16 +55,16 @@ export class QueryHistory extends React.Component {
   constructor(props) {
     super(props);
     this.historyStore = new QueryStore('queries', props.storage);
-    this.favoriteStore = new QueryStore('favorites', props.storage);
+    this.selectedForTestingStore = new QueryStore('testing', props.storage);
     const historyQueries = this.historyStore.fetchAll();
-    const favoriteQueries = this.favoriteStore.fetchAll();
-    const queries = historyQueries.concat(favoriteQueries);
-    this.state = { queries };
+    this.state = { historyQueries };
   }
 
   componentWillReceiveProps(nextProps) {
+    // ensure no duplicates will be created, pass all existing queries into shouldSaveQuery
+    const allHistoryQueries = this.historyStore.fetchAll() || [];
     if (
-      shouldSaveQuery(nextProps, this.props, this.historyStore.fetchRecent())
+      shouldSaveQuery(nextProps, this.props, allHistoryQueries)
     ) {
       const item = {
         query: nextProps.query,
@@ -76,11 +76,9 @@ export class QueryHistory extends React.Component {
       if (this.historyStore.length > MAX_HISTORY_LENGTH) {
         this.historyStore.shift();
       }
-      const historyQueries = this.historyStore.items;
-      const favoriteQueries = this.favoriteStore.items;
-      const queries = historyQueries.concat(favoriteQueries);
+      const newListOfHistoryQueries = this.historyStore.items;
       this.setState({
-        queries,
+        historyQueries: newListOfHistoryQueries,
       });
     }
   }


### PR DESCRIPTION
Changes made to HistoryQuery.js

- Response inherited as a prop from parent
- shouldSaveQuery will go through all existing queries in the history store and ensure no duplicate queries are created. 
- Created a separate function for creating the query nodes.
- Selecting a query for testing will be stored in selectedForTestingStore and will show that it has been clicked. 
