### PR TITLE
demo server with test schema

### DIFF
--- a/demo/server.js
+++ b/demo/server.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const graphqlHTTP = require('express-graphql');
+const cors = require("cors");
+const PORT = 3000;
+
+const schema = require("./schema/schema");
+const app = express();
+
+app.use(cors());
+
+app.use('/graphql', graphqlHTTP(() => ({ schema, graphiql: false })));
+
+app.listen(PORT, () => {
+  console.log(`Server started at port ${PORT}`);
+});

--- a/helpers.js
+++ b/helpers.js
@@ -75,14 +75,13 @@ export function updateURL() {
 export function graphQLFetcher(graphQLParams) {
   // This example expects a GraphQL server at the path /graphql.
   // Change this to point wherever you host your GraphQL server.
-  return fetch("/graphql", {
+  return fetch("http://localhost:3000/graphql", {
     method: "post",
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json"
     },
     body: JSON.stringify(graphQLParams),
-    credentials: "include"
   })
     .then(function(response) {
       return response.text();

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "babel-cli": "^6.26.0",
     "babel-loader": "^8.0.2",
     "copy-webpack-plugin": "^4.5.2",
+    "cors": "^2.8.4",
     "css-loader": "^1.0.0",
+    "express-graphql": "^0.6.12",
     "extract-text-webpack-plugin": "4.0.0-beta.0",
     "file-loader": "^2.0.0",
     "graphql": "^14.0.2",
@@ -78,6 +80,7 @@
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
+    "request": "^2.88.0",
     "reselect": "^3.0.1",
     "svg-pan-zoom": "^3.5.3",
     "viz.js": "^2.0.0"


### PR DESCRIPTION
added a server.js
also had to modify helpers.js to use the appropriate URL for fetches.

The server must (for now) be started manually using
>node demo/server.js

which will run it on localhost:3000. the fetcher has this new url.
added cors to the package json, express-graphql, as well as request (probably don't need...)