### PR TITLE
Functionality to toggle Voyager is complete

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,11 +25,13 @@
             flex-direction:column;
             justify-content:center;
           }
-
+          
+          /* temporary hard-code solution to fix the height of loadingbox - Jon 9/18/17 */
           .loading-box {
             height: 60vh;
           }
 
+          /* temporary hard-code solution to fix the popover box - Jon 9/18/17 */
           .type-info-popover {
             display: none;
           }

--- a/index.html
+++ b/index.html
@@ -25,21 +25,25 @@
             flex-direction:column;
             justify-content:center;
           }
-      
-          #viz {
+
+          .loading-box {
             height: 60vh;
           }
 
+          .type-info-popover {
+            display: none;
+          }
+      
           #graphiql {
-            height: 40vh;
+            height: 100vh;
           }
         </style>
     </head>
     <body>
        <main>
-          <div id="graphiql">Loading...</div>
-<div id="viz"></div>
-
+         <div id="viz"></div>
+         <div id="graphiql">Loading...</div>
+         
         </main> 
         
     </body>

--- a/index.tsx
+++ b/index.tsx
@@ -1,31 +1,7 @@
 import * as React from "react";
 import {render} from "react-dom";
-import { MuiThemeProvider } from "@material-ui/core/styles";
-
-import { theme } from "./src/visualizer/components/MUITheme";
-import { GraphQLVoyager } from "./src/visualizer";
-
 import { GraphiQL } from "./src/components/GraphiQL";
-
-import schema from "./demo/schema/schema";
 import * as helpers from "./helpers.js";
-
-export default class Viz extends React.Component {
-  public render() {
-    return (
-      <MuiThemeProvider theme={theme}>
-        <GraphQLVoyager introspection={schema} />
-      </MuiThemeProvider>
-    );
-  }
-}
-
-
-
-render(
-    <Viz />,
-  document.getElementById("viz")
-);
 
 render(
   <GraphiQL 

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -9,6 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import { buildClientSchema, GraphQLSchema, parse, print } from 'graphql';
+import {render} from "react-dom";
 
 import { ExecuteButton } from './ExecuteButton';
 import { ToolbarButton } from './ToolbarButton';
@@ -32,6 +33,7 @@ import {
   introspectionQuery,
   introspectionQuerySansSubscriptions,
 } from '../utility/introspectionQueries';
+import Viz from '../visualizer/viz';
 
 const DEFAULT_DOC_EXPLORER_WIDTH = 350;
 
@@ -63,6 +65,7 @@ export class GraphiQL extends React.Component {
     editorTheme: PropTypes.string,
     onToggleHistory: PropTypes.func,
     ResultsTooltip: PropTypes.any,
+    showVoya: PropTypes.bool,
   };
 
   constructor(props) {
@@ -119,6 +122,7 @@ export class GraphiQL extends React.Component {
       isWaitingForResponse: false,
       subscription: null,
       ...queryFacts,
+      showVoya: false,
     };
 
     // Ensure only the last executed editor query is rendered.
@@ -284,6 +288,27 @@ export class GraphiQL extends React.Component {
       height: variableOpen ? this.state.variableEditorHeight : null,
     };
 
+    const viz = document.getElementById('viz');
+    const graph = document.getElementById('graphiql');
+    const menu = document.getElementsByClassName('menu-content');
+    console.log(menu);
+
+    if (this.state.showVoya) {
+      viz.style.height = "60vh";
+      graph.style.height = "40vh";
+
+      render(
+        <Viz />,
+        document.getElementById("viz")
+      );
+    } 
+    else {
+      graph.style.height = "100vh";
+      viz.style.height = "0vh";
+      // don't use, don't make user re-render. 
+      // ReactDOM.unmountComponentAtNode(document.getElementById('viz'));
+    }
+
     return (
       <div className="graphiql-container">
         <div className="historyPaneWrap" style={historyPaneStyle}>
@@ -312,6 +337,7 @@ export class GraphiQL extends React.Component {
               />
               {toolbar}
             </div>
+            <button onClick={() => this.testing()}>test</button>
             {!this.state.docExplorerOpen &&
               <button
                 className="docExplorerShow"
@@ -396,6 +422,11 @@ export class GraphiQL extends React.Component {
         </div>
       </div>
     );
+  }
+
+  testing() {
+    let bool = !this.state.showVoya
+    this.setState({ showVoya: bool })
   }
 
   /**

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -31,7 +31,7 @@ import {
   introspectionQuery,
   introspectionQuerySansSubscriptions,
 } from '../utility/introspectionQueries';
-import Viz from '../visualizer/viz';
+import Viz from '../visualizer';
 
 const DEFAULT_DOC_EXPLORER_WIDTH = 350;
 

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -7,10 +7,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
+import { ReactDOM, render } from 'react-dom';
 import { buildClientSchema, GraphQLSchema, parse, print } from 'graphql';
-import {render} from "react-dom";
-
 import { ExecuteButton } from './ExecuteButton';
 import { ToolbarButton } from './ToolbarButton';
 import { ToolbarGroup } from './ToolbarGroup';
@@ -65,7 +63,7 @@ export class GraphiQL extends React.Component {
     editorTheme: PropTypes.string,
     onToggleHistory: PropTypes.func,
     ResultsTooltip: PropTypes.any,
-    showVoya: PropTypes.bool,
+    showVoyager: PropTypes.bool,
   };
 
   constructor(props) {
@@ -122,7 +120,7 @@ export class GraphiQL extends React.Component {
       isWaitingForResponse: false,
       subscription: null,
       ...queryFacts,
-      showVoya: false,
+      showVoyager: false,
     };
 
     // Ensure only the last executed editor query is rendered.
@@ -293,7 +291,7 @@ export class GraphiQL extends React.Component {
     const menu = document.getElementsByClassName('menu-content');
     console.log(menu);
 
-    if (this.state.showVoya) {
+    if (this.state.showVoyager) {
       viz.style.height = "60vh";
       graph.style.height = "40vh";
 
@@ -425,8 +423,8 @@ export class GraphiQL extends React.Component {
   }
 
   testing() {
-    let bool = !this.state.showVoya
-    this.setState({ showVoya: bool })
+    let bool = !this.state.showVoyager
+    this.setState({ showVoyager: bool })
   }
 
   /**

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -286,25 +286,23 @@ export class GraphiQL extends React.Component {
       height: variableOpen ? this.state.variableEditorHeight : null,
     };
 
-    const viz = document.getElementById('viz');
-    const graph = document.getElementById('graphiql');
-    const menu = document.getElementsByClassName('menu-content');
-    console.log(menu);
+    const vizDOMElement = document.getElementById('viz');
+    const graphiqlDOMElement = document.getElementById('graphiql');
 
     if (this.state.showVoyager) {
-      viz.style.height = "60vh";
-      graph.style.height = "40vh";
+      // resize to display both components
+      vizDOMElement.style.height = "60vh";
+      graphiqlDOMElement.style.height = "40vh";
 
+      // display Voyageur
       render(
         <Viz />,
         document.getElementById("viz")
       );
-    } 
-    else {
-      graph.style.height = "100vh";
-      viz.style.height = "0vh";
-      // don't use, don't make user re-render. 
-      // ReactDOM.unmountComponentAtNode(document.getElementById('viz'));
+    } else {
+      // resize to only display graphiql
+      graphiqlDOMElement.style.height = "100vh";
+      vizDOMElement.style.height = "0vh";
     }
 
     return (
@@ -335,7 +333,7 @@ export class GraphiQL extends React.Component {
               />
               {toolbar}
             </div>
-            <button onClick={() => this.testing()}>test</button>
+            <button onClick={() => this.showVoyager()}>Show Voyager</button>
             {!this.state.docExplorerOpen &&
               <button
                 className="docExplorerShow"
@@ -422,9 +420,9 @@ export class GraphiQL extends React.Component {
     );
   }
 
-  testing() {
-    let bool = !this.state.showVoyager
-    this.setState({ showVoyager: bool })
+  showVoyager() {
+    const bool = !this.state.showVoyager;
+    this.setState({ showVoyager: bool });
   }
 
   /**

--- a/src/visualizer/index.tsx
+++ b/src/visualizer/index.tsx
@@ -1,5 +1,15 @@
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import * as React from "react";
+import { theme } from "./components/MUITheme";
+import { Voyager } from "./components";
+import schema from "../../demo/schema/schema";
 
-import { Voyager } from './components';
-
-
-export { Voyager as GraphQLVoyager, Voyager };
+export default class Viz extends React.Component {
+  public render() {
+    return (
+      <MuiThemeProvider theme={theme}>
+        <Voyager introspection={schema} />
+      </MuiThemeProvider>
+    );
+  }
+}

--- a/src/visualizer/viz.tsx
+++ b/src/visualizer/viz.tsx
@@ -1,0 +1,21 @@
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import * as React from "react";
+// import {render} from "react-dom";
+import { theme } from "./components/MUITheme";
+import { GraphQLVoyager } from ".";
+import schema from "../../demo/schema/schema";
+
+export default class Viz extends React.Component {
+  public render() {
+    return (
+      <MuiThemeProvider theme={theme}>
+        <GraphQLVoyager introspection={schema} />
+      </MuiThemeProvider>
+    );
+  }
+}
+
+// render(
+//     <Viz />,
+//   document.getElementById("viz")
+// );

--- a/src/visualizer/viz.tsx
+++ b/src/visualizer/viz.tsx
@@ -1,6 +1,5 @@
 import { MuiThemeProvider } from "@material-ui/core/styles";
 import * as React from "react";
-// import {render} from "react-dom";
 import { theme } from "./components/MUITheme";
 import { GraphQLVoyager } from ".";
 import schema from "../../demo/schema/schema";
@@ -14,8 +13,3 @@ export default class Viz extends React.Component {
     );
   }
 }
-
-// render(
-//     <Viz />,
-//   document.getElementById("viz")
-// );


### PR DESCRIPTION
Changes made:

index.html

- Removed viz id tag in index.html, DOM element will be dynamically changed in GraphiQl.js
- #graphiql DOM element’s height is initialized at 100vh, will be changed if showVoyager has been toggled. 
- .loading-box refers to the voyager loading display. Re-adjust height to fix size of Voyager component. 
    - Should further look into the css files to enact permanent changes there. 
- .type-info-popover set to hidden, will need to look further into this.
- Voyager will now be displayed at the top and graphical at the bottom. 

index.tsx
- Moved Viz Class and all related imports into it’s own file and placed it in src/visualizer/
    - refer to viz.tsx
- index.tsx will only render GraphiQL component. 

GraphiQL.js
- Imported render from react-dom and Viz to display Viz Component
- showVoyager is now a property of the GraphiQL Component, in state, and a method that work together to display Voyager.
