### PR TITLE
Selecting query shows response in window

### DIFF
--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -9,6 +9,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ReactDOM, render } from 'react-dom';
 import { buildClientSchema, GraphQLSchema, parse, print } from 'graphql';
+
 import { ExecuteButton } from './ExecuteButton';
 import { ToolbarButton } from './ToolbarButton';
 import { ToolbarGroup } from './ToolbarGroup';
@@ -31,7 +32,7 @@ import {
   introspectionQuery,
   introspectionQuerySansSubscriptions,
 } from '../utility/introspectionQueries';
-import Viz from '../visualizer/viz';
+import Viz from '../visualizer';
 
 const DEFAULT_DOC_EXPLORER_WIDTH = 350;
 

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -7,10 +7,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom';
+import { ReactDOM, render } from 'react-dom';
 import { buildClientSchema, GraphQLSchema, parse, print } from 'graphql';
-import {render} from "react-dom";
-
 import { ExecuteButton } from './ExecuteButton';
 import { ToolbarButton } from './ToolbarButton';
 import { ToolbarGroup } from './ToolbarGroup';
@@ -65,7 +63,7 @@ export class GraphiQL extends React.Component {
     editorTheme: PropTypes.string,
     onToggleHistory: PropTypes.func,
     ResultsTooltip: PropTypes.any,
-    showVoya: PropTypes.bool,
+    showVoyager: PropTypes.bool,
   };
 
   constructor(props) {
@@ -122,7 +120,7 @@ export class GraphiQL extends React.Component {
       isWaitingForResponse: false,
       subscription: null,
       ...queryFacts,
-      showVoya: false,
+      showVoyager: false,
     };
 
     // Ensure only the last executed editor query is rendered.
@@ -293,7 +291,7 @@ export class GraphiQL extends React.Component {
     const menu = document.getElementsByClassName('menu-content');
     console.log(menu);
 
-    if (this.state.showVoya) {
+    if (this.state.showVoyager) {
       viz.style.height = "60vh";
       graph.style.height = "40vh";
 
@@ -425,8 +423,8 @@ export class GraphiQL extends React.Component {
   }
 
   testing() {
-    let bool = !this.state.showVoya
-    this.setState({ showVoya: bool })
+    let bool = !this.state.showVoyager
+    this.setState({ showVoyager: bool })
   }
 
   /**

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -286,25 +286,23 @@ export class GraphiQL extends React.Component {
       height: variableOpen ? this.state.variableEditorHeight : null,
     };
 
-    const viz = document.getElementById('viz');
-    const graph = document.getElementById('graphiql');
-    const menu = document.getElementsByClassName('menu-content');
-    console.log(menu);
+    const vizDOMElement = document.getElementById('viz');
+    const graphiqlDOMElement = document.getElementById('graphiql');
 
     if (this.state.showVoyager) {
-      viz.style.height = "60vh";
-      graph.style.height = "40vh";
+      // resize to display both components
+      vizDOMElement.style.height = "60vh";
+      graphiqlDOMElement.style.height = "40vh";
 
+      // display Voyageur
       render(
         <Viz />,
         document.getElementById("viz")
       );
-    } 
-    else {
-      graph.style.height = "100vh";
-      viz.style.height = "0vh";
-      // don't use, don't make user re-render. 
-      // ReactDOM.unmountComponentAtNode(document.getElementById('viz'));
+    } else {
+      // resize to only display graphiql
+      graphiqlDOMElement.style.height = "100vh";
+      vizDOMElement.style.height = "0vh";
     }
 
     return (
@@ -335,7 +333,7 @@ export class GraphiQL extends React.Component {
               />
               {toolbar}
             </div>
-            <button onClick={() => this.testing()}>test</button>
+            <button onClick={() => this.showVoyager()}>Show Voyager</button>
             {!this.state.docExplorerOpen &&
               <button
                 className="docExplorerShow"
@@ -422,9 +420,9 @@ export class GraphiQL extends React.Component {
     );
   }
 
-  testing() {
-    let bool = !this.state.showVoyager
-    this.setState({ showVoyager: bool })
+  showVoyager() {
+    const bool = !this.state.showVoyager;
+    this.setState({ showVoyager: bool });
   }
 
   /**

--- a/src/components/GraphiQL.js
+++ b/src/components/GraphiQL.js
@@ -826,10 +826,12 @@ export class GraphiQL extends React.Component {
     this.setState({ historyPaneOpen: !this.state.historyPaneOpen });
   };
 
-  handleSelectHistoryQuery = (query, variables, operationName) => {
+  handleSelectHistoryQuery = (query, variables, operationName, response) => {
     this.handleEditQuery(query);
     this.handleEditVariables(variables);
     this.handleEditOperationName(operationName);
+    // reset state with passed in response so it is displayed when query is selected
+    this.setState({ response });
   };
 
   handleResizeStart = downEvent => {

--- a/src/components/HistoryQuery.js
+++ b/src/components/HistoryQuery.js
@@ -89,9 +89,9 @@ export default class HistoryQuery extends React.Component {
     this.props.onSelect(
       this.props.query,
       this.props.variables,
-      this.props.response,
       this.props.operationName,
-      this.props.label,
+      this.props.response,
+      this.props.label, // Jon: may not need, is not accepted as an argument in the function - refer to GraphiQL.js : HandleSelectHistoryQuery
     );
   }
 

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -73,9 +73,14 @@ export class QueryHistory extends React.Component {
         response: nextProps.response,
       };
       this.historyStore.push(item);
+      
+      // -------  Jon 9/19/18 -----------
+      // revisit this section, if user favorites a query and the query is at the beginning of the array
+      // it will get removed
       if (this.historyStore.length > MAX_HISTORY_LENGTH) {
         this.historyStore.shift();
       }
+      // ------------------------------------
       const newListOfHistoryQueries = this.historyStore.items;
       this.setState({
         historyQueries: newListOfHistoryQueries,

--- a/src/components/QueryHistory.js
+++ b/src/components/QueryHistory.js
@@ -142,6 +142,7 @@ export class QueryHistory extends React.Component {
       this.historyStore.edit(item);
       this.selectedForTestingStore.delete(item);
     }
+
     // set state with the changed queries
     const historyQueries = this.historyStore.items;
     this.setState({ historyQueries });

--- a/src/visualizer/index.tsx
+++ b/src/visualizer/index.tsx
@@ -1,5 +1,15 @@
+import { MuiThemeProvider } from "@material-ui/core/styles";
+import * as React from "react";
+import { theme } from "./components/MUITheme";
+import { Voyager } from "./components";
+import schema from "../../demo/schema/schema";
 
-import { Voyager } from './components';
-
-
-export { Voyager as GraphQLVoyager, Voyager };
+export default class Viz extends React.Component {
+  public render() {
+    return (
+      <MuiThemeProvider theme={theme}>
+        <Voyager introspection={schema} />
+      </MuiThemeProvider>
+    );
+  }
+}


### PR DESCRIPTION
Changes made:

package-lock.json
- deleted after merge conflicts. 

Graphiql.js
- handleSelectHistoryQuery now accepts response as an additional argument. This value will be utilized to show the response in the response window of graphiQL when the query is selected.  

HistoryQuery.js
- Fixed the order of the arguments when calling this.props.onSelect()

QueryHistory.js
- Added comments on blocks of code that can potentially be removed