### PR TITLE
Parser fixed

### DIFF
--- a/cypress/integration/parser.unit.test.ts
+++ b/cypress/integration/parser.unit.test.ts
@@ -47,7 +47,7 @@ describe("Unit tests", () => {
 
   
 
-    xit("should properly parse out a Connection after adding fields", () => {
+    it("should properly parse out a Connection after adding fields", () => {
       const array = [
         "allFilms",
         "edges",

--- a/src/queryRunner/components/GraphiQL.js
+++ b/src/queryRunner/components/GraphiQL.js
@@ -230,7 +230,6 @@ export class GraphiQL extends React.Component {
       this.resultComponent
     ]);
     let previousQueryModeQuery = previousProps.queryModeQuery;
-    // console.log('q passed from Matcha')
     if (this.props.queryModeQuery !== "") {
       if (previousQueryModeQuery !== this.props.queryModeQuery) {
         this.setState({ query: this.props.queryModeQuery });

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -1,4 +1,3 @@
-//TODO adds an extra
 import { isEmpty, last as lastElementOf } from "lodash";
 
 

--- a/src/utils/parsers.ts
+++ b/src/utils/parsers.ts
@@ -45,12 +45,11 @@ function braceRemainingElements(array:Array<any>, queryStr:string): string {
   for (let i = secondToLastIdx; i >=0; i--) {
     let element = array[i];
     let nextEle = array[i-1];
-    console.log('parsing ', element);
     queryStr = areFields(element)
     ? brace(element.join(" ") + queryStr)
     : !areFields(nextEle)
       ? brace(element + queryStr)
-      : element + queryStr;
+      : ' ' + element + queryStr;
   }
   return queryStr;
 }


### PR DESCRIPTION
A space is now prepended to the query string when processing a node that is preceeded by a list of selected fields.

I enabled the test for this case, and it is passing. 

Also removed some unnecessary console logs and comments