### PR TITLE
Button Upgraded 

### DIFF
--- a/cypress/integration/e2e.test.js
+++ b/cypress/integration/e2e.test.js
@@ -8,6 +8,7 @@ describe("Integration tests", () => {
     cy.get(".vis-control > button").should("be.disabled");
     cy.wait(1500);
     cy.get(".vis-control > button").should("be.enabled");
+    cy.wait(500);
     cy.contains("Hide Schema").click();
   });
 
@@ -16,7 +17,7 @@ describe("Integration tests", () => {
     cy.wait(1000);
     cy.get(".vis-control > button").click();
     cy.wait(600);
-    cy.get(".vis-control > button").click();
+    cy.get('.loader').click();
   });
 
   it("selects starship node, enters draft mode to focus on ROOT", () => {
@@ -43,7 +44,7 @@ describe("Integration tests", () => {
 
   it("clicks film field, exits query mode, runs the query with result", () => {
     cy.get(":nth-child(1) > .doc-category > :nth-child(2)").click();
-    cy.get(".vis-control > button").click();
+    cy.get('.loader').click();
     cy.get(".execute-button").click();
     cy.wait(1200);
     //check results
@@ -118,7 +119,7 @@ describe("Integration tests", () => {
   });
 
   it("exits query mode, and keeps the last generated query", () => {
-    cy.get(".vis-control > button").click();
+    cy.get('.loader').click();
     cy.contains(".query-editor", "{allPlanets{edges{node{climates name}}}}");
   });
 

--- a/demo/matcha.css
+++ b/demo/matcha.css
@@ -35,6 +35,7 @@ main {
  flex:1;
  padding:0px;
  justify-content: center;
+ max-width: 50px;
 }
 
 .Collapsible {
@@ -1956,3 +1957,191 @@ li.CodeMirror-hint-active {
 .CodeMirror-hint-deprecation :last-child {
   margin-bottom: 0;
 }
+
+.loader {
+  position: relative;
+  height: 100px;
+  width: 100px;
+}
+
+
+.hexContainer{
+    position: relative;
+    top: 27.5px;
+    -webkit-animation: spin 2.5s ease-in-out infinite;
+      animation: spin 2.5s ease-in-out infinite;
+}
+.hex {
+    width: 80px;
+    height: 45px;
+    background:#EB38A5;
+    margin: auto auto;
+    position: relative;
+  }
+  .hex:before, .hex:after {
+    content: "";
+    position: absolute;
+    width: 0;
+    height: 0;
+  }
+  .hex:before {
+    top: -24px;
+    left: 0;
+    border-left: 40px solid transparent;
+    border-right: 40px solid transparent;
+    border-bottom: 25px solid#EB38A5;
+  }
+  .hex:after {
+    bottom: -24px;
+    left: 0;
+    border-left: 40px solid transparent;
+    border-right: 40px solid transparent;
+    border-top: 25px solid #EB38A5;
+  }
+  .inner {
+    background-color:white;
+    -webkit-transform: scale(.86, .86);
+    -moz-transform: scale(.86, .86);
+    transform: scale(.86, .86);
+    z-index:1;
+    }
+    .inner:before {
+    border-bottom: 25px solid white;
+    }
+    .inner:after {
+    border-top: 25px solid white;
+    } 
+
+
+.triangleContainer {
+  position: absolute;
+  top: 0px;
+}
+.triangle {
+    display: inline-block;
+    height: 15px;
+    position: absolute;
+    top: -4px;
+    left: 15px;
+    z-index: 3;
+    border-bottom: solid 59px #EB38A5;
+    border-right: solid 35px transparent;
+    border-left: solid 35px transparent;
+  }
+  .triangleInner {
+    display: inline-block;
+    height: 15px;
+    position: absolute;
+    top: 11px;
+    left: -24px;
+    z-index: 4;
+    border-bottom: solid 42px white;
+    border-right: solid 24px transparent;
+    border-left: solid 24px transparent;
+  }
+
+  
+  .ballContainer {
+      position: absolute;
+      top: 7px;
+      left: 7px;
+      z-index: 5;
+      height: 86px;
+      width: 86px;
+      border-radius: 50%;
+      -webkit-animation: spin 2.5s ease-in-out 1s infinite;
+      /* animation: spin 2.5s ease-in-out 1s infinite; */
+      animation: shrink 2.5s ease-in-out infinite;
+  }
+  .balls {
+    height: 86px;
+    width: 86px;
+    border-radius: 50%;
+    position: absolute;
+    z-index: 6;
+  }
+  .balls:after {
+    content: "";
+    height: 20px;
+    width: 20px;
+    border-radius: 50%;
+    background-color: #EB38A5;
+    position: relative;
+    display: block;
+
+  }
+  .ball1:after {
+    left: -2px;
+    top: 14px;
+  }
+  .ball2:after {
+    left: 33px;
+    top: -8px;
+  }
+  .ball3:after {
+    left: 70px;
+    top: 14px;
+  }
+  .ball4:after {
+    left: 70px;
+    top: 53px;
+  }
+  .ball5:after {
+    left: 33px;
+    top: 75px;
+  }
+  .ball6:after {
+    left: -2px;
+    top: 53px;
+  }
+
+
+    @-webkit-keyframes spin {
+      0% {
+        -webkit-transform: rotate(0deg);
+                transform: rotate(0deg);
+      }
+      100% {
+        -webkit-transform: rotate(360deg);
+                transform: rotate(360deg);
+      }
+    }
+    @keyframes spin {
+      0% {
+        -webkit-transform: rotate(0deg);
+                transform: rotate(0deg);
+      }
+      100% {
+        -webkit-transform: rotate(360deg);
+                transform: rotate(360deg);
+      }
+    }
+
+    @-webkit-keyframes shrink {
+      0% {
+        -webkit-transform: scale(1);
+                transform: scale(1);
+      }
+      50% {
+        -webkit-transform: scale(0.2);
+                transform: scale(0.2);
+      }
+      100% {
+        -webkit-transform: scale(1);
+                transform: scale(1);
+      }
+    }
+    @keyframes shrink {
+      0% {
+        -webkit-transform: scale(1);
+                transform: scale(1);
+      }
+      50% {
+        -webkit-transform: scale(0.2);
+                transform: scale(0.);
+      }
+      100% {
+        -webkit-transform: scale(1);
+                transform: scale(1);
+      }
+    }

--- a/demo/matcha.css
+++ b/demo/matcha.css
@@ -28,7 +28,7 @@ main {
 }
 
 .vis-control{
-  flex: 1;
+  
 }
 
 .vis-control button{

--- a/demo/matcha.css
+++ b/demo/matcha.css
@@ -28,8 +28,9 @@ main {
 }
 
 .vis-control{
-  display:flex;
+  flex: 1;
 }
+
 .vis-control button{
  display:flex;
  flex:1;
@@ -1999,17 +2000,17 @@ li.CodeMirror-hint-active {
     border-top: 25px solid #EB38A5;
   }
   .inner {
-    background-color:white;
+    background-color:rgb(18, 20, 20);
     -webkit-transform: scale(.86, .86);
     -moz-transform: scale(.86, .86);
     transform: scale(.86, .86);
     z-index:1;
     }
     .inner:before {
-    border-bottom: 25px solid white;
+    border-bottom: 25px solid rgb(18, 20, 20);
     }
     .inner:after {
-    border-top: 25px solid white;
+    border-top: 25px solid rgb(18, 20, 20);
     } 
 
 
@@ -2035,7 +2036,7 @@ li.CodeMirror-hint-active {
     top: 11px;
     left: -24px;
     z-index: 4;
-    border-bottom: solid 42px white;
+    border-bottom: solid 42px rgb(18, 20, 20);
     border-right: solid 24px transparent;
     border-left: solid 24px transparent;
   }

--- a/demo/matcha.css
+++ b/demo/matcha.css
@@ -27,16 +27,13 @@ main {
   height: 60vh;
 }
 
-.vis-control{
-  
-}
-
 .vis-control button{
- display:flex;
- flex:1;
- padding:0px;
- justify-content: center;
- max-width: 50px;
+  color: white;
+  font: 14px 'helvetica neue', helvetica, arial, sans-serif;
+  background-color: #42a0dd;
+  border-radius: 2px;
+  line-height: 24px;
+  border: 1px solid #999;
 }
 
 .Collapsible {
@@ -1963,6 +1960,7 @@ li.CodeMirror-hint-active {
   position: relative;
   height: 100px;
   width: 100px;
+  cursor: pointer;
 }
 
 

--- a/src/components/Matcha.tsx
+++ b/src/components/Matcha.tsx
@@ -36,6 +36,8 @@ export default class Matcha extends React.Component<null, MatchaStateTypes> {
 
   queryModeHandler(connections): void {
     if (this.state) {
+      // we need to exit out of query mode if query mode is enabled and nothing is selected
+        // spoke with sean about this at 11PM - 10/1/18 - Jon
       if (!connections.history.length) return;
       let queryStack = connections.history;
       if (connections.currentFields && connections.currentFields.length) {

--- a/src/loader/Logo.js
+++ b/src/loader/Logo.js
@@ -7,8 +7,7 @@ export default class Logo extends React.Component {
 
   render() {
     return (
-      <div type="button" onClick={this.props.toggleQueryMode}>
-      <div className="loader">
+      <div className="loader" type="button" onClick={this.props.toggleQueryMode}>
       <div  className="hexContainer">
           <div className="hex">
               <div className="hex inner"></div>
@@ -26,7 +25,6 @@ export default class Logo extends React.Component {
           <div className="balls ball4"></div>
           <div className="balls ball5"></div>
           <div className="balls ball6"></div>
-      </div>
       </div>
       </div>
     )

--- a/src/loader/Logo.js
+++ b/src/loader/Logo.js
@@ -8,7 +8,7 @@ export default class Logo extends React.Component {
   render() {
     return (
       <div className="loader" type="button" onClick={this.props.toggleQueryMode}>
-      <div  className="hexContainer">
+      <div className="hexContainer">
           <div className="hex">
               <div className="hex inner"></div>
           </div>

--- a/src/loader/Logo.js
+++ b/src/loader/Logo.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+export default class Logo extends React.Component {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div type="button" onClick={this.props.toggleQueryMode}>
+      <div className="loader">
+      <div  className="hexContainer">
+          <div className="hex">
+              <div className="hex inner"></div>
+          </div>
+      </div>
+      <div className="triangleContainer">
+          <div className="triangle">
+              <div className="triangleInner"></div>
+          </div>
+      </div>
+      <div className="ballContainer">
+          <div className="balls ball1"></div>
+          <div className="balls ball2"></div>
+          <div className="balls ball3"></div>
+          <div className="balls ball4"></div>
+          <div className="balls ball5"></div>
+          <div className="balls ball6"></div>
+      </div>
+      </div>
+      </div>
+    )
+  }
+}

--- a/src/visualizer/components/Voyager.tsx
+++ b/src/visualizer/components/Voyager.tsx
@@ -124,7 +124,7 @@ export default class Voyager extends React.Component<VoyagerProps> {
     if (nextProps.inQueryMode && !this.props.inQueryMode) {
       this.unsubscribe = this.store.subscribe(() => {
         const { selected } = this.store.getState();
-        const storedSelections = { history:selected.queryModeHistory, currentFields: selected.multipleEdgeIds };
+        const storedSelections = { history:selected.queryModeHistory, currentFields: selected.multipleEdgeIds, currentNodeId: selected.currentNodeId};
         return this.props.queryModeHandler(storedSelections);
       });
       //TODO abstract this into getRootFromProps()

--- a/src/visualizer/components/doc-explorer/DocNavigation.css
+++ b/src/visualizer/components/doc-explorer/DocNavigation.css
@@ -1,7 +1,7 @@
 @import '../variables.css';
 
 .doc-navigation {
-  min-height: var(--icons-size);
+  /* min-height: 115px; */
   box-shadow: 0 4px 4px -2px var(--shadow-color);
   display: flex;
   justify-content: space-between;
@@ -21,6 +21,8 @@
     white-space: nowrap;
     padding-left: 2px;
     font-weight: normal;
+    flex: 1;
+    text-align: left;
 
     &:before {
       border-left: 2px solid var(--field-name-color);
@@ -39,6 +41,9 @@
     font-weight: bold;
     color: var(--primary-color);
     font-weight: bold;
+    display: flex;
+    flex: 1;
+    justify-content: flex-end
   }
 
   & > .header {

--- a/src/visualizer/components/doc-explorer/DocNavigation.css
+++ b/src/visualizer/components/doc-explorer/DocNavigation.css
@@ -1,7 +1,6 @@
 @import '../variables.css';
 
 .doc-navigation {
-  /* min-height: 115px; */
   box-shadow: 0 4px 4px -2px var(--shadow-color);
   display: flex;
   justify-content: space-between;

--- a/src/visualizer/components/doc-explorer/DocNavigation.tsx
+++ b/src/visualizer/components/doc-explorer/DocNavigation.tsx
@@ -65,6 +65,7 @@ class DocNavigation extends React.Component<DocNavigationProps> {
       )
     }
 
+    // determine size depndent 
     let minHeight = '24px';
     if (this.props.inQueryMode) {
       minHeight = '115px';

--- a/src/visualizer/components/doc-explorer/DocNavigation.tsx
+++ b/src/visualizer/components/doc-explorer/DocNavigation.tsx
@@ -12,6 +12,8 @@ interface DocNavigationProps {
   previousType: any;
   dispatch: any;
   inQueryMode: boolean;
+  svg: string;
+  toggleQueryMode: any;
 }
 
 function mapStateToProps(state) {
@@ -38,6 +40,18 @@ class DocNavigation extends React.Component<DocNavigationProps> {
       }
     };
 
+    const toggleDraftButton = () => {
+      let disabled = true;
+      if (this.props.svg) disabled = false;
+      return (
+        <div className="vis-control">
+          <button disabled={disabled} type="button" onClick={this.props.toggleQueryMode}>
+            Draft Query
+        </button>
+        </div>
+      )
+    }
+
     return (
       <div className="doc-navigation">
         {(selectedType && (
@@ -45,6 +59,9 @@ class DocNavigation extends React.Component<DocNavigationProps> {
             {previousType ? previousType.name : 'Type List'}
           </span>
         )) || <span className="header">Type List</span>}
+
+        {toggleDraftButton()}
+
         {selectedType && (
           <span className="active">
             {selectedType.name} <FocusTypeButton type={selectedType} />

--- a/src/visualizer/components/doc-explorer/DocNavigation.tsx
+++ b/src/visualizer/components/doc-explorer/DocNavigation.tsx
@@ -65,8 +65,13 @@ class DocNavigation extends React.Component<DocNavigationProps> {
       )
     }
 
+    let minHeight = '24px';
+    if (this.props.inQueryMode) {
+      minHeight = '115px';
+    }
+
     return (
-      <div className="doc-navigation">
+      <div className="doc-navigation" style={{ minHeight }}>
         {(selectedType && (
           <span className="back" onClick={clickHandler}>
             {previousType ? previousType.name : 'Type List'}

--- a/src/visualizer/components/doc-explorer/DocNavigation.tsx
+++ b/src/visualizer/components/doc-explorer/DocNavigation.tsx
@@ -7,7 +7,7 @@ import { getSelectedType, getPreviousType } from '../../selectors';
 import { selectPreviousType, clearSelection, focusElement, previousNodeAndEdges } from '../../actions/';
 import FocusTypeButton from './FocusTypeButton';
 
-import Logo from '../../../loader/Logo.js';
+import GraphQLLogo from './GraphQLLogo';
 
 interface DocNavigationProps {
   selectedType: any;
@@ -54,7 +54,7 @@ class DocNavigation extends React.Component<DocNavigationProps> {
 
       if (this.props.inQueryMode) {
         display = (
-          <Logo toggleQueryMode={this.props.toggleQueryMode}/>
+          <GraphQLLogo toggleQueryMode={this.props.toggleQueryMode}/>
         )
       }
 

--- a/src/visualizer/components/doc-explorer/DocNavigation.tsx
+++ b/src/visualizer/components/doc-explorer/DocNavigation.tsx
@@ -7,6 +7,8 @@ import { getSelectedType, getPreviousType } from '../../selectors';
 import { selectPreviousType, clearSelection, focusElement, previousNodeAndEdges } from '../../actions/';
 import FocusTypeButton from './FocusTypeButton';
 
+import Logo from '../../../loader/Logo.js';
+
 interface DocNavigationProps {
   selectedType: any;
   previousType: any;
@@ -43,11 +45,22 @@ class DocNavigation extends React.Component<DocNavigationProps> {
     const toggleDraftButton = () => {
       let disabled = true;
       if (this.props.svg) disabled = false;
+
+      let display = (
+        <button disabled={disabled} type="button" onClick={this.props.toggleQueryMode}>
+          Draft Query
+        </button>
+      );
+
+      if (this.props.inQueryMode) {
+        display = (
+          <Logo toggleQueryMode={this.props.toggleQueryMode}/>
+        )
+      }
+
       return (
         <div className="vis-control">
-          <button disabled={disabled} type="button" onClick={this.props.toggleQueryMode}>
-            Draft Query
-        </button>
+          {display}
         </div>
       )
     }

--- a/src/visualizer/components/doc-explorer/DocNavigation.tsx
+++ b/src/visualizer/components/doc-explorer/DocNavigation.tsx
@@ -48,7 +48,7 @@ class DocNavigation extends React.Component<DocNavigationProps> {
 
       let display = (
         <button disabled={disabled} type="button" onClick={this.props.toggleQueryMode}>
-          Draft Query
+          Activate Query mode
         </button>
       );
 

--- a/src/visualizer/components/doc-explorer/GraphQLLogo.tsx
+++ b/src/visualizer/components/doc-explorer/GraphQLLogo.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+interface GraphQLLogoProps {
+  toggleQueryMode: any;
+}
+
+export default class GraphQLLogo extends React.Component<GraphQLLogoProps> {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div className="loader" data-type="button" onClick={this.props.toggleQueryMode}>
+      <div className="hexContainer">
+          <div className="hex">
+              <div className="hex inner"></div>
+          </div>
+      </div>
+      <div className="triangleContainer">
+          <div className="triangle">
+              <div className="triangleInner"></div>
+          </div>
+      </div>
+      <div className="ballContainer">
+          <div className="balls ball1"></div>
+          <div className="balls ball2"></div>
+          <div className="balls ball3"></div>
+          <div className="balls ball4"></div>
+          <div className="balls ball5"></div>
+          <div className="balls ball6"></div>
+      </div>
+      </div>
+    )
+  }
+}

--- a/src/visualizer/components/doc-explorer/ShamaltaLogo.tsx
+++ b/src/visualizer/components/doc-explorer/ShamaltaLogo.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+
+interface ShamaltaLogoProps {
+  toggleQueryMode: any;
+}
+
+export default class ShamaltaLogo extends React.Component<ShamaltaLogoProps> {
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div className="loader" data-type="button" onClick={this.props.toggleQueryMode}>
+      <div className="hexContainer">
+          <div className="hex">
+              <div className="hex inner"></div>
+          </div>
+      </div>
+      <div className="triangleContainer">
+          <div className="triangle">
+              <div className="triangleInner"></div>
+          </div>
+      </div>
+      <div className="ballContainer">
+          <div className="balls ball1"></div>
+          <div className="balls ball2"></div>
+          <div className="balls ball3"></div>
+          <div className="balls ball4"></div>
+          <div className="balls ball5"></div>
+          <div className="balls ball6"></div>
+      </div>
+      </div>
+    )
+  }
+}

--- a/src/visualizer/components/doc-explorer/TypeDoc.tsx
+++ b/src/visualizer/components/doc-explorer/TypeDoc.tsx
@@ -182,25 +182,12 @@ class TypeDoc extends React.Component<TypeDocProps> {
       );
     }
 
-    //TODO: move this up to matcha, and pass down the whole button!
-    //won't need to pass down toggle function anymore.
-
-    const toggleDraftButton = props => {
-      let disabled = true;
-      if (props.svg) disabled = false;
-      return (
-        <div className="vis-control">
-          <button disabled={disabled} type="button" onClick={props.toggleQueryMode}>
-            Draft Query
-        </button>
-        </div>
-      )
-    }
-
     return (
       <div className="type-doc">
-        <DocNavigation inQueryMode={this.props.inQueryMode} />
-        {toggleDraftButton(this.props)}
+        <DocNavigation 
+          inQueryMode={this.props.inQueryMode} 
+          svg={this.props.svg}
+          toggleQueryMode={this.props.toggleQueryMode}/>
         <div className="scroll-area">
           {!selectedType ? (
             <TypeList typeGraph={typeGraph} />


### PR DESCRIPTION
Files Changed:

- Button moved into DocNavigation from TypeDoc
- GraphQLLogo class created for logo that will be displayed, called inside of DocNavigation
- Inside of shouldComponentUpdate, attempted to fix issue of exiting query mode if initial state is empty/nothing is selected. Needs to be looked into further, comments made inside of Matcha.tsx to address this. 

CSS changed:

- Removed min-height from DocNavigation.css
- Min-height will be set in DocNavigation.tsx, value dependent on whether or not queryMode is enabled.  - Min-height initially set at 24px, 115px for query Mode
- Tons of CSS added for graphQL Logo that will display when query mode is enabled
- DocNavigation back class has flex set to 1 & text-align set to left
- DocNavigation's active class has flex set to 1 & justify-content: flex-end
